### PR TITLE
no sync file open

### DIFF
--- a/custom_components/inmet_weather/api.py
+++ b/custom_components/inmet_weather/api.py
@@ -1,19 +1,13 @@
 """INMET Weather API Client."""
 
-import asyncio
 from datetime import datetime
-import json
 import logging
 import math
-import os
-import tempfile
 import time
 from typing import Any, Dict, Optional, List
 
 import aiohttp
 import async_timeout
-
-from .const import GEOCODE_CACHE_FILE
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/inmet_weather/const.py
+++ b/custom_components/inmet_weather/const.py
@@ -6,9 +6,6 @@ DEFAULT_NAME = "INMET Weather"
 # Update interval in seconds (every 30 minutes)
 UPDATE_INTERVAL = 1800
 
-# Geocode cache settings
-GEOCODE_CACHE_FILE = ".inmet_geocode_cache.json"
-
 # Conditions
 CONDITION_SUNNY = "sunny"
 CONDITION_CLEAR_NIGHT = "clear-night"


### PR DESCRIPTION
Removing sync open cache file because of

```
2025-11-10 03:29:15.988 WARNING (MainThread) [homeassistant.util.loop] Detected blocking call to open with args ('/config/custom_components/inmet_weather/gadm41_BRA_0.json', 'r') inside the event loop by custom integration 'inmet_weather' at custom_components/inmet_weather/geo_utils.py, line 90: with open(_GEOJSON_FILE, "r", encoding="utf-8") as f: (offender: /config/custom_components/inmet_weather/geo_utils.py, line 90: with open(_GEOJSON_FILE, "r", encoding="utf-8") as f:), please create a bug report at https://github.com/zanaca/ha-inmet-weather/issues
For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#open```